### PR TITLE
Fixed yaw

### DIFF
--- a/src/goto_plugin_position.cpp
+++ b/src/goto_plugin_position.cpp
@@ -60,10 +60,8 @@ namespace goto_plugin_position
             switch (goal->yaw_mode_flag)
             {
             case as2_msgs::action::GoToWaypoint::Goal::FIXED_YAW:
-            {
                 yaw_goal_ = as2::FrameUtils::getYawFromQuaternion(goal->target_pose.orientation);
                 break;
-            }
             case as2_msgs::action::GoToWaypoint::Goal::KEEP_YAW:
                 yaw_goal_ = getActualYaw();
                 break;
@@ -71,7 +69,7 @@ namespace goto_plugin_position
                 Eigen::Vector3d actual_position = getActualPosition();
                 yaw_goal_ = computeFacingAngle(actual_position, desired_position_);
                 break;
-                return rclcpp_action::GoalResponse::REJECT;
+            return rclcpp_action::GoalResponse::REJECT;
             }
 
             // TODO: Use the yaw_mode_flag to set the yaw_goal_ when Python Interface supports it
@@ -143,7 +141,7 @@ namespace goto_plugin_position
             }
             return speed;
         }
-        
+
         Eigen::Vector3d getActualPosition()
         {
             pose_mutex_.lock();

--- a/src/goto_plugin_speed.cpp
+++ b/src/goto_plugin_speed.cpp
@@ -44,7 +44,7 @@ namespace goto_plugin_speed
     {
     private:
         bool proportional_speed_limit_ = false;
-    
+
     public:
         void ownInit()
         {
@@ -53,7 +53,7 @@ namespace goto_plugin_speed
                 node_ptr_->declare_parameter<bool>("goto_proportional_speed_limit");
                 proportional_speed_limit_ = node_ptr_->get_parameter("goto_proportional_speed_limit").as_bool();
             }
-            catch(const rclcpp::ParameterTypeException& e)
+            catch (const rclcpp::ParameterTypeException &e)
             {
                 RCLCPP_ERROR(node_ptr_->get_logger(), "Launch argument <goto_proportional_speed_limit> not defined or malformed: %s", e.what());
                 // this->~Plugin();
@@ -121,7 +121,10 @@ namespace goto_plugin_speed
                     desired_yaw = getDesiredYawAngle(speed_setpoint);
                 }
                 */
-                desired_yaw_ = desired_yaw;
+                
+                if(ignore_yaw_ || speed_setpoint.head(2).norm() > 0.1f)
+                    desired_yaw_ = desired_yaw;
+                    
                 Eigen::Vector3d speed(speed_setpoint.x(), speed_setpoint.y(), speed_setpoint.z());
 
                 // Delimit the speed for each axis
@@ -129,7 +132,10 @@ namespace goto_plugin_speed
                 {
                     for (short j = 0; j < 3; j++)
                     {
-                        if (desired_speed_ == 0.0f || speed[j] == 0.0) {continue;};
+                        if (desired_speed_ == 0.0f || speed[j] == 0.0)
+                        {
+                            continue;
+                        };
 
                         if (speed[j] > desired_speed_ || speed[j] < -desired_speed_)
                         {

--- a/src/goto_plugin_speed.cpp
+++ b/src/goto_plugin_speed.cpp
@@ -107,7 +107,7 @@ namespace goto_plugin_speed
                 pose_mutex_.unlock();
 
                 desired_yaw = ignore_yaw_ ? getActualYaw() : getDesiredYawAngle(speed_setpoint);
-
+                /*
                 if (ignore_yaw_)
                 {
                     desired_yaw = getActualYaw();
@@ -120,7 +120,8 @@ namespace goto_plugin_speed
                 {
                     desired_yaw = getDesiredYawAngle(speed_setpoint);
                 }
-
+                */
+                desired_yaw_ = desired_yaw;
                 Eigen::Vector3d speed(speed_setpoint.x(), speed_setpoint.y(), speed_setpoint.z());
 
                 // Delimit the speed for each axis

--- a/src/goto_plugin_speed.cpp
+++ b/src/goto_plugin_speed.cpp
@@ -122,25 +122,13 @@ namespace goto_plugin_speed
                     RCLCPP_WARN_ONCE(node_ptr_->get_logger(), "Unsupported YAW mode");
                 }
 
-                //desired_yaw = ignore_yaw_ ? getActualYaw() : getDesiredYawAngle(speed_setpoint);
-                /*
-                if (ignore_yaw_)
+                if (goal->yaw_mode_flag == as2_msgs::action::GoToWaypoint::Goal::KEEP_YAW || 
+                    goal->yaw_mode_flag == as2_msgs::action::GoToWaypoint::Goal::FIXED_YAW ||
+                    speed_setpoint.head(2).norm() > 0.1f)
                 {
-                    desired_yaw = getActualYaw();
-                }
-                else if (!ignore_yaw_ && speed_setpoint.head(2).norm() < 2.0f)
-                {
-                    desired_yaw = getActualYaw();
-                }
-                else
-                {
-                    desired_yaw = getDesiredYawAngle(speed_setpoint);
-                }
-                */
-
-                if (ignore_yaw_ || goal->yaw_mode_flag == as2_msgs::action::GoToWaypoint::Goal::FIXED_YAW ||speed_setpoint.head(2).norm() > 0.1f)
                     desired_yaw_ = desired_yaw;
-
+                }    
+                    
                 Eigen::Vector3d speed(speed_setpoint.x(), speed_setpoint.y(), speed_setpoint.z());
 
                 // Delimit the speed for each axis


### PR DESCRIPTION
New control on yaw with a desired yaw (FIXED_YAW). Goal is finished when the drone reaches the target waypoint with the desired yaw.

# YAW CONTROL MODES
- KEEP_YAW: use the current yaw as desired
- PATH_FACING: desired yaw matches forward direction
- FIXED_YAW: use a given yaw angle as fixed desired yaw (needs **yaw_angle**)

Yaw control modes need to be reconsider in order to standardize this changes to all as2_behaviours 